### PR TITLE
Increasing code coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "system-image-node-module",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "UBports System image client/server module",
   "main": "./src/module.js",
   "scripts": {

--- a/src/client.js
+++ b/src/client.js
@@ -175,7 +175,7 @@ class Client {
   }
 
   // FIXME: Some people might perfer to get the latest *version* instead
-  getLatestVesion(device, channel) {
+  getLatestVersion(device, channel) {
     return this.getDeviceIndex(device, channel).then((index) => {
       //TODO optimize with searching in reverse, but foreach is safer
       // to use now to be sure we get latest version

--- a/tests/unit-tests/test_client.js
+++ b/tests/unit-tests/test_client.js
@@ -86,6 +86,17 @@ describe('Client module', function() {
         expect(err.message).to.equal("Host is not a valid URL!");
       };
     });
+
+    it("should return invalid url with no host", function() {
+      try {
+        const sic = new SystemImageClient({
+          path: "./custom-test",
+          cache_time: 240
+        });
+      } catch (err) {
+        expect(err.message).to.equals("Host is not a valid URL!");
+      };
+    });
   });
 
   describe("createInstallCommands()", function() {

--- a/tests/unit-tests/test_client.js
+++ b/tests/unit-tests/test_client.js
@@ -194,14 +194,14 @@ describe('Client module', function() {
     });
   });
 
-  describe("getLatestVesion()", function() {
+  describe("getLatestVersion()", function() {
     it("should return latest version", function() {
       const requestStub = this.sandbox.stub(request, 'get').callsFake(function(url, cb) {
         cb(false, {statusCode: 200}, baconIndexJson);
       });
 
       const sic = new SystemImageClient();
-      return sic.getLatestVesion("bacon", "ubports-touch/15.04/devel").then((result) => {
+      return sic.getLatestVersion("bacon", "ubports-touch/15.04/devel").then((result) => {
         expect(result).to.eql(baconLatestVersionJson);
         expect(requestStub).to.have.been.calledWith({
           url: "https://system-image.ubports.com/ubports-touch/15.04/devel/bacon/index.json",
@@ -215,7 +215,7 @@ describe('Client module', function() {
         cb(true, {statusCode: 500}, baconIndexJson);
       });
       const sic = new SystemImageClient();
-      return sic.getLatestVesion("bacon", "ubports-touch/15.04/devel").then(() => {}).catch((err) => {
+      return sic.getLatestVersion("bacon", "ubports-touch/15.04/devel").then(() => {}).catch((err) => {
         expect(err).to.eql(true);
         expect(requestStub).to.have.been.calledWith({
           url: "https://system-image.ubports.com/ubports-touch/15.04/devel/bacon/index.json",

--- a/tests/unit-tests/test_client.js
+++ b/tests/unit-tests/test_client.js
@@ -111,6 +111,25 @@ describe('Client module', function() {
       var result = sic.createInstallCommands(4, true, true, [1, 2, 3]);
       expect(result).to.eql(false);
     });
+
+    it("should not add 'format data' when wipe === false", function() {
+      const sic = new SystemImageClient();
+      var result = sic.createInstallCommands(baconLatestVersionJson.files, true, false, true, [1, 2, 3]);
+      expect(result).to.not.contain("\nformat data");
+    });
+
+    it("should not add 'enabled' when enable is set to false", function() {
+      const sic = new SystemImageClient();
+      var result = sic.createInstallCommands(baconLatestVersionJson.files, true, true, false, [1, 2, 3]);
+      expect(result).to.not.contain("\nenable\n");
+    });
+
+    it("should not add 'installer_check' when installerCheck === false", function() {
+      const sic = new SystemImageClient();
+      var result = sic.createInstallCommands(baconLatestVersionJson.files, false, true, true, [1, 2, 3]);
+      expect(result).to.not.contain("\ninstaller_check");
+    })
+
   });
 
   describe("createInstallCommandsFile()", function() {


### PR DESCRIPTION
- Adds one more test to `client.js` constructor where no host was passed.
- Adds a few more test scenarios to `createInstallCommands` method.